### PR TITLE
Fix config to point to new resource

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-#dont need this anymore, but useful for test deployment
-version: '3'
-
 services:
   landing-pages:
 #    build: .
@@ -9,6 +6,8 @@ services:
     ports:
       - "5000:80"
     restart: always
+    environment:
+      - PYGEOAPI_URL=http://localhost:5000
     volumes:
        - ./data:/data
        - ./pygeoapi.config.yml:/pygeoapi/local.config.yml

--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -33,7 +33,7 @@ server:
     bind:
         host: localhost #change to your hostname if running your own instance
         port: 5000
-    url: http://localhost:5000 # change to host URL if running your own instance
+    url: ${PYGEOAPI_URL} # change to host URL if running your own instance
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: true

--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -92,7 +92,7 @@ resources:
             - type: application/html
               rel: canonical
               title: data source
-              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/72612518-e45b-4900-9cab-72b8de09c57d
+              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/ab3f524c-850f-40e4-b27a-6cae7154add5
               hreflang: en-US
         extents:
             spatial:
@@ -120,7 +120,7 @@ resources:
             - type: application/html
               rel: canonical
               title: data source
-              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/72612518-e45b-4900-9cab-72b8de09c57d
+              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/ab3f524c-850f-40e4-b27a-6cae7154add5
               hreflang: en-US
         extents:
             spatial:
@@ -145,7 +145,7 @@ resources:
             - type: application/html
               rel: canonical
               title: data source
-              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/72612518-e45b-4900-9cab-72b8de09c57d
+              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/ab3f524c-850f-40e4-b27a-6cae7154add5
               hreflang: en-US
         extents:
             spatial:
@@ -171,7 +171,7 @@ resources:
             - type: application/html
               rel: canonical
               title: data source
-              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/72612518-e45b-4900-9cab-72b8de09c57d
+              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/ab3f524c-850f-40e4-b27a-6cae7154add5
               hreflang: en-US
         extents:
             spatial:
@@ -196,7 +196,7 @@ resources:
             - type: application/html
               rel: canonical
               title: data source
-              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/72612518-e45b-4900-9cab-72b8de09c57d
+              href: https://data.ca.gov/dataset/gsp-monitoring-data/resource/ab3f524c-850f-40e4-b27a-6cae7154add5
               hreflang: en-US
         extents:
             spatial:
@@ -209,7 +209,7 @@ resources:
             - type: feature
               name: CKAN
               data: https://data.ca.gov/api/3/action/datastore_search
-              resource_id: 72612518-e45b-4900-9cab-72b8de09c57d
+              resource_id: ab3f524c-850f-40e4-b27a-6cae7154add5
               id_field: EXISTING_INFO_ID
               x_field: LONGITUDE
               y_field: LATITUDE

--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -210,6 +210,6 @@ resources:
               name: CKAN
               data: https://data.ca.gov/api/3/action/datastore_search
               resource_id: ab3f524c-850f-40e4-b27a-6cae7154add5
-              id_field: EXISTING_INFO_ID
+              id_field: SITE_CODE
               x_field: LONGITUDE
               y_field: LATITUDE


### PR DESCRIPTION
Fixes https://github.com/cgs-earth/pygeoapi-geoconnex-examples/issues/1 and makes pygeoapi use a resource which is valid and doesn't 404

Kyle said
> also the id_field: is now evidently SITE_CODE

However, I did not find that to be the case. I am finding that I can query fine without changing the `id_field` but if i change it to SITE_CODE it causes an error. 

```
landing-pages-1  |   File "/pygeoapi/pygeoapi/provider/sqlite.py", line 265, in __load
landing-pages-1  |     assert len([item for item in result
landing-pages-1  | AssertionError: id_field not present
```